### PR TITLE
README: the ID doesn't need to be URL encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The GitLab host to trigger the pipeline on. Default `gitlab.com`.
 
 ### `id`
 
-**Required** The ID or URL-encoded path of the project owned by the authenticated user.
+**Required** The ID or path of the project owned by the authenticated user.
 
 ### `ref`
 


### PR DESCRIPTION
From what I see this was copied from the gitlab docs, but we urlencode the path in JS, so double encoding would be wrong here.