### PR TITLE
feat: add invalid access/trigger token error handling

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2869,6 +2869,16 @@ const pollPipeline = async (host, projectId, token, pipelineId, webUrl) => {
                     'Accept': 'application/json',
                 },
             });
+
+            if (!response.ok) {
+                let errorMessage = `GitLab API returned status code ${response.status}.`;
+                if (response.status === 401) {
+                    errorMessage = "Unauthorized: invalid/expired access token was used.";
+                }
+                core.setFailed(errorMessage);
+                break;
+            }
+
             const data = await response.json();
 
             status = data.status;
@@ -2917,6 +2927,15 @@ async function run() {
                 variables: variables,
             }),
         });
+
+        if (!response.ok) {
+            let errorMessage = `GitLab API returned status code ${response.status}.`;
+            if (response.status === 404) {
+                errorMessage = "The specified resource does not exist, or an invalid/expired trigger token was used.";
+            }
+            return core.setFailed(errorMessage);
+        }
+
         const data = await response.json();
 
         core.setOutput("id", data.id);

--- a/index.js
+++ b/index.js
@@ -35,6 +35,16 @@ const pollPipeline = async (host, projectId, token, pipelineId, webUrl) => {
                     'Accept': 'application/json',
                 },
             });
+
+            if (!response.ok) {
+                let errorMessage = `GitLab API returned status code ${response.status}.`;
+                if (response.status === 401) {
+                    errorMessage = "Unauthorized: invalid/expired access token was used.";
+                }
+                core.setFailed(errorMessage);
+                break;
+            }
+
             const data = await response.json();
 
             status = data.status;
@@ -83,6 +93,15 @@ async function run() {
                 variables: variables,
             }),
         });
+
+        if (!response.ok) {
+            let errorMessage = `GitLab API returned status code ${response.status}.`;
+            if (response.status === 404) {
+                errorMessage = "The specified resource does not exist, or an invalid/expired trigger token was used.";
+            }
+            return core.setFailed(errorMessage);
+        }
+
         const data = await response.json();
 
         core.setOutput("id", data.id);


### PR DESCRIPTION
Adding invalid access/trigger token error handling:
- GitLab returns 404 HTTP status code on requests with an invalid trigger token, as a security measure. Exit immediately.
- GitLab returns 401 HTTP status code on requests with an invalid access token. Exit immediately.

Fixes: #34

