### PR TITLE
Variables optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For public projects you don't need to provide an access token.
 
 ### `variables`
 
-A map of key-valued strings containing the pipeline variables. For example: `{ VAR1: "value1", VAR2: "value2" }`.. Default `"World"`.
+A map of key-valued strings containing the pipeline variables. For example: `{ VAR1: "value1", VAR2: "value2" }`. The value has to be valid JSON. If not set the default is `{}`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ inputs:
   variables:
     description: 'A map of key-valued strings containing the pipeline variables. For example: { VAR1: "value1", VAR2: "value2" }.'
     required: false
+    default: '{}'
 outputs:
   status:
     description: 'The status of the pipeline.'


### PR DESCRIPTION
The `variables` option is set as not required in action.yml but has no default.

If not set, the action just returns a cryptic error (`undefined:1`).

I've added the default - an empty JSON object.
I've also documented this in README.md.

This should fix it, but I'm not fluent in github action code or javascript for that matter, so please tell me if something is wrong. The code does build but wasn't tested otherwise.