### PR TITLE
fix the documentation on required role for pipeline access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ to trigger the pipeline.
 ### `access_token`
 
 The [GitLab pipeline access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html)
-to access the pipeline via the API. You need the `read_api` and `read_repository` scopes with `Guest` role for this token.
+to access the pipeline via the API. You need the `read_api` and `read_repository` scopes with `Reporter` role for this token.
 
 For public projects you don't need to provide an access token.
 


### PR DESCRIPTION
Adding a token with role `Guest` as written in the README.md failed the job with error 403 from Gitlab.

Changing the role to `Reporter` worked for me. It's possible that `Guest` is enough combined with some Gitlab option, but setting it to `Reporter` works for sure.