### PR TITLE
Move the artifacts files into a subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,14 @@ The artifacts and logs are organized as follows:
 ```
 download_path/
 ├── job_123_job_name_1/
-│   ├── artifact1.txt    # Artifacts (if download_artifacts enabled)
-│   ├── artifact2.txt    # Artifacts (if download_artifacts enabled)
+│   ├── artifacts/       # Artifacts subdirectory (if download_artifacts enabled)
+│   │   ├── artifact1.txt
+│   │   └── artifact2.txt
 │   └── job.log          # Console output (if download_job_logs enabled)
 ├── job_124_job_name_2/
-│   ├── build/           # Artifacts (if download_artifacts enabled)
-│   ├── dist/            # Artifacts (if download_artifacts enabled)
+│   ├── artifacts/       # Artifacts subdirectory (if download_artifacts enabled)
+│   │   ├── build/
+│   │   └── dist/
 │   └── job.log          # Console output (if download_job_logs enabled)
 └── ...
 ```

--- a/dist/index.js
+++ b/dist/index.js
@@ -31113,21 +31113,23 @@ const downloadArtifacts = async (
                 }
 
                 const artifactBuffer = await artifactResponse.arrayBuffer();
-                const jobArtifactsPath = path.join(
+                const jobPath = path.join(
                     downloadPath,
                     `job_${job.id}_${job.name.replace(/[^a-zA-Z0-9]/g, '_')}`,
                 );
 
                 // Create job-specific directory
-                await io.mkdirP(jobArtifactsPath);
+                await io.mkdirP(jobPath);
 
                 // Save the zip file
-                const zipPath = path.join(jobArtifactsPath, 'artifacts.zip');
+                const zipPath = path.join(jobPath, 'artifacts.zip');
                 fs.writeFileSync(zipPath, Buffer.from(artifactBuffer));
 
                 // Extract the zip file
+                const artifactsPath = path.join(jobPath, 'artifacts');
+                await io.mkdirP(artifactsPath);
                 const zip = new AdmZip(zipPath);
-                zip.extractAllTo(jobArtifactsPath, true);
+                zip.extractAllTo(artifactsPath, true);
 
                 // Remove the zip file after extraction
                 fs.unlinkSync(zipPath);

--- a/index.js
+++ b/index.js
@@ -265,21 +265,23 @@ const downloadArtifacts = async (
                 }
 
                 const artifactBuffer = await artifactResponse.arrayBuffer();
-                const jobArtifactsPath = path.join(
+                const jobPath = path.join(
                     downloadPath,
                     `job_${job.id}_${job.name.replace(/[^a-zA-Z0-9]/g, '_')}`,
                 );
 
                 // Create job-specific directory
-                await io.mkdirP(jobArtifactsPath);
+                await io.mkdirP(jobPath);
 
                 // Save the zip file
-                const zipPath = path.join(jobArtifactsPath, 'artifacts.zip');
+                const zipPath = path.join(jobPath, 'artifacts.zip');
                 fs.writeFileSync(zipPath, Buffer.from(artifactBuffer));
 
                 // Extract the zip file
+                const artifactsPath = path.join(jobPath, 'artifacts');
+                await io.mkdirP(artifactsPath);
                 const zip = new AdmZip(zipPath);
-                zip.extractAllTo(jobArtifactsPath, true);
+                zip.extractAllTo(artifactsPath, true);
 
                 // Remove the zip file after extraction
                 fs.unlinkSync(zipPath);


### PR DESCRIPTION
Instead of having them in the same dir as the logs. To avoid filename conflicts, and to make future additions easier.